### PR TITLE
Fix ensure_ascii for ToolNode

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/tool_node.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_node.py
@@ -16,7 +16,7 @@ def str_output(output: Any) -> str:
         return output
     else:
         try:
-            return json.dumps(output)
+            return json.dumps(output, ensure_ascii=False)
         except Exception:
             return str(output)
 


### PR DESCRIPTION
ToolNode serializes its message (ToolMessage) content as JSON with ensure_ascii=True which will result in Unicode code points (like `\uXXXX') instead of characters shown in the events stream.
The value of ensured_ascii changed to False